### PR TITLE
Removing hard-coded solr location

### DIFF
--- a/solr/files/v7/core/conf/solrcore.properties
+++ b/solr/files/v7/core/conf/solrcore.properties
@@ -17,4 +17,3 @@ solr.autoCommit.MaxTime=120000
 solr.autoSoftCommit.MaxDocs=2000
 # autoSoftCommit after 10 seconds
 solr.autoSoftCommit.MaxTime=10000
-solr.install.dir=../../..


### PR DESCRIPTION
Per this issue: https://www.drupal.org/project/search_api_solr/issues/3015993

Existence of this directive causes the wrong libraries to get loaded for the core and the schema won't apply to the core.